### PR TITLE
Revert "[eap-additional-testsuite] : testing .gitAttributes"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - git init
   - git remote add origin https://github.com/wildfly/wildfly.git
   - git pull origin 10.0.0.Alpha1
-  - mvn clean install -DskipTests > output2.txt
+  - mvn clean install -DskipTests > output.txt
   - cd ..
   - export JBOSS_FOLDER=$PWD'/wildfly/dist/target/wildfly-10.0.0.Alpha1'
   - mvn clean install -Dwildfly


### PR DESCRIPTION
Reverts jboss-set/eap-additional-testsuite#4 : test did not work. .travis.yml was replaced while it was supposed not to.
