### PR TITLE
add a generic script for jenkins jobs

### DIFF
--- a/jenkins-job.sh
+++ b/jenkins-job.sh
@@ -1,0 +1,25 @@
+if [ -z "${LOCAL_REPO_DIR}" ]; then
+  echo "Missing LOCAL_REPO_DIR - please provide value to the local maven repo to use"
+  exit 1
+fi
+
+if [ -z "${JBOSS_FOLDER}" && ! -d "${JBOSS_FOLDER}" ]; then
+  echo "Missing JBOSS_FOLDER variable or not pointing to a directory: ${JBOSS_FOLDER}"
+  exit 2
+fi
+
+if [ -z "${JBOSS_VERSION}" ]; then
+  echo "Missing JBOSS_VERSION - please provide JBOSS AS version used."
+  exit 3
+fi
+
+if [ -z "${JBOSS_VERSION_CODE}" ]; then
+  echo "Missing JBOSS_VERSION_CODE (eap7, eap64,...)."
+  exit 4
+fi
+
+export MAVEN_OPTS="-Xmx1024m -Xms512m -XX:MaxPermSize=256m"
+# remove previous build
+rm -r -f eap*
+
+mvn clean install -D${JBOSS_VERSION_CODE} -Dstandalone -Dmaven.repo.local=${LOCAL_REPO_DIR}


### PR DESCRIPTION
This script is generic version that can be used by ALL the jobs currently running on our Jenkins server.

The following job (not publicly available) has been modified to use it [jboss-additional-testsuite-eap7-build](http://thunder.sin2.redhat.com:8480/jenkins/job/jboss-additional-testsuite-eap7-build/), and here is the [run associated to it](http://thunder.sin2.redhat.com:8480/jenkins/job/jboss-additional-testsuite-eap7-build/7/console).

Let me know if you like and merge the script, I'll update all the other jobs. 

Note Bene: The script is name jenkins-job.sh but could actually be used to run the project locally, provided the requested envVar are set.
