### PR TITLE
Enable and extend JaxbProviderDeserializationSecurityCheckTestCase

### DIFF
--- a/modules/src/main/java/org/apache/ibatis/datasource/jndi/JndiDataSourceFactory.java
+++ b/modules/src/main/java/org/apache/ibatis/datasource/jndi/JndiDataSourceFactory.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyleft 2018, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.apache.ibatis.datasource.jndi;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import java.util.Properties;
+
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+public class JndiDataSourceFactory {
+    Properties properties;
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+}

--- a/modules/src/main/java/org/hibernate/jmx/StatisticsService.java
+++ b/modules/src/main/java/org/hibernate/jmx/StatisticsService.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyleft 2018, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.hibernate.jmx;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+public class StatisticsService {
+    private String sessionFactoryJNDIName;
+
+    public String getSessionFactoryJNDIName() {
+        return sessionFactoryJNDIName;
+    }
+
+    public void setSessionFactoryJNDIName(String sessionFactoryJNDIName) {
+        this.sessionFactoryJNDIName = sessionFactoryJNDIName;
+    }
+}

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbProviderDeserializationSecurityCheckTestCase.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbProviderDeserializationSecurityCheckTestCase.java
@@ -56,7 +56,7 @@ import org.springframework.jacksontest.BogusPointcutAdvisor;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//@apAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
 public class JaxbProviderDeserializationSecurityCheckTestCase {
 
     @Deployment(testable = false)

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbProviderDeserializationSecurityCheckTestCase.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbProviderDeserializationSecurityCheckTestCase.java
@@ -32,6 +32,8 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -39,7 +41,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+import org.springframework.jacksontest.BogusApplicationContext;
 import org.springframework.jacksontest.BogusPointcutAdvisor;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * Tests a JAX-RS deployment without an application bundled.
@@ -56,7 +64,7 @@ import org.springframework.jacksontest.BogusPointcutAdvisor;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java"})
 public class JaxbProviderDeserializationSecurityCheckTestCase {
 
     @Deployment(testable = false)
@@ -64,7 +72,10 @@ public class JaxbProviderDeserializationSecurityCheckTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class,"jaxrssecurity.war");
         war.addPackage(HttpRequest.class.getPackage());
         war.addClasses(JaxbProviderDeserializationSecurityCheckTestCase.class, JaxbResourceDeserializationSecurityCheck.class,ExampleApplication.class,
-                       org.springframework.jacksontest.BogusPointcutAdvisor.class, org.springframework.jacksontest.AbstractPointcutAdvisor.class);
+                       org.springframework.jacksontest.BogusPointcutAdvisor.class, org.springframework.jacksontest.AbstractPointcutAdvisor.class,
+                       org.springframework.jacksontest.BogusApplicationContext.class, org.springframework.jacksontest.AbstractApplicationContext.class,
+                       org.apache.ibatis.datasource.jndi.JndiDataSourceFactory.class, org.hibernate.jmx.StatisticsService.class,
+                       TestMapperResolver.class);
         return war;
     }
 
@@ -76,8 +87,8 @@ public class JaxbProviderDeserializationSecurityCheckTestCase {
     }
 
     @Test
-    public void testJaxRsWithNoApplication() throws Exception {
-        String result = performCall("rest/jaxb");
+    public void testPointcutAdvisor() throws Exception {
+        String result = performCall("rest/jaxb/advisor");
 
         try{
             BogusPointcutAdvisor jaxbModel = new ObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false).readValue(result, BogusPointcutAdvisor.class);
@@ -85,8 +96,61 @@ public class JaxbProviderDeserializationSecurityCheckTestCase {
         }catch(JsonMappingException e){
             Assert.assertTrue("Should prevente json deserialization because of security reasons.", e.getMessage().contains("Illegal type"));
         }
-    
+
     }
+
+    @Test
+    public void testApplicationContext() throws Exception {
+        String result = performCall("rest/jaxb/appcontext");
+
+        try{
+            BogusApplicationContext jaxbModel = new ObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false).readValue(result, BogusApplicationContext.class);
+            Assert.fail("Should prevente json deserialization because of security reasons.");
+        }catch(JsonMappingException e){
+            Assert.assertTrue("Should prevente json deserialization because of security reasons.", e.getMessage().contains("Illegal type"));
+        }
+
+    }
+
+    @Test
+    public void testStatisticsService(){
+        doRequestAndExpectIllegalTypeMessage(getStatisticsService());
+    }
+
+    @Test
+    public void testMyBatisJndiDataSourceFactory(){
+        doRequestAndExpectIllegalTypeMessage(getMyBatisJndiDataSourceFactory());
+    }
+
+    private void doRequestAndExpectIllegalTypeMessage(String nastyJson) {
+        ResteasyClient client = null;
+        Response response = null;
+        try {
+            client = new ResteasyClientBuilder().build();
+            Invocation.Builder request = client.target(url + "rest/jaxb/bad").request();
+            response = request.post(Entity.entity(nastyJson, MediaType.APPLICATION_JSON_TYPE));
+            Assert.assertEquals("The request should fail because of security reasons!", 400, response.getStatus());
+            Assert.assertTrue("The response should contain \"Illegal type\"", response.readEntity(String.class).contains("Illegal type"));
+        } finally {
+            response.close();
+            client.close();
+        }
+    }
+
+    private String getMyBatisJndiDataSourceFactory(){
+        String s = "['org.apache.ibatis.datasource.jndi.JndiDataSourceFactory',{'properties':{'data_source':'ldap://localhost:1389/obj'}}]";
+        return aposToQuotes(s);
+    }
+
+    private String getStatisticsService(){
+        String s = "['org.hibernate.jmx.StatisticsService',{'sessionFactoryJNDIName':'ldap://localhost:1389/obj'}]";
+        return aposToQuotes(s);
+    }
+
+    private String aposToQuotes(String json) {
+        return json.replace("'", "\"");
+    }
+
 
 
 }

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbResourceDeserializationSecurityCheck.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/JaxbResourceDeserializationSecurityCheck.java
@@ -21,12 +21,16 @@
  */
 package org.jboss.additional.testsuite.jdkall.present.jaxrs.jaxb;
 
+import org.springframework.jacksontest.BogusApplicationContext;
 import org.springframework.jacksontest.BogusPointcutAdvisor;
 import java.io.IOException;
 import java.rmi.RemoteException;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
 
@@ -35,10 +39,29 @@ import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
 @EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
 public class JaxbResourceDeserializationSecurityCheck {
     @GET
-    @Produces("application/json")
-    public Response get() throws RemoteException, IOException {
+    @Path("advisor")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAdvisor() throws RemoteException, IOException {
         BogusPointcutAdvisor obj = new BogusPointcutAdvisor();
 
         return Response.ok().entity(obj).build();
     }
+
+    @GET
+    @Path("appcontext")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAppContext() throws RemoteException, IOException {
+        BogusApplicationContext obj = new BogusApplicationContext();
+
+        return Response.ok().entity(obj).build();
+    }
+
+    @POST
+    @Path("bad")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response uhoh(Object o) throws Exception {
+        System.out.println(o.getClass().getName());
+        return Response.ok(o.getClass().getName()).build();
+    }
+
 }

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/TestMapperResolver.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/jaxrs/jaxb/TestMapperResolver.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyleft 2018, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.additional.testsuite.jdkall.present.jaxrs.jaxb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+public class TestMapperResolver implements ContextResolver<ObjectMapper> {
+
+    private ObjectMapper objectMapper;
+
+    public TestMapperResolver(){
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.enableDefaultTyping();
+        System.out.println("enabled Default Typing");
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return objectMapper;
+    }
+
+}

--- a/modules/src/main/java/org/springframework/jacksontest/AbstractApplicationContext.java
+++ b/modules/src/main/java/org/springframework/jacksontest/AbstractApplicationContext.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyleft 2018, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.springframework.jacksontest;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+public class AbstractApplicationContext {
+}

--- a/modules/src/main/java/org/springframework/jacksontest/BogusApplicationContext.java
+++ b/modules/src/main/java/org/springframework/jacksontest/BogusApplicationContext.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyleft 2018, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.springframework.jacksontest;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/jaxrs/src/main/java","modules/testcases/jdkAll/Eap7/jaxrs/src/main/java","modules/testcases/jdkAll/Eap71x/jaxrs/src/main/java","modules/testcases/jdkAll/Eap70x/jaxrs/src/main/java"})
+@XmlRootElement
+public class BogusApplicationContext extends AbstractApplicationContext {
+}


### PR DESCRIPTION
This PR enables JaxbProviderDeserializationSecurityCheckTestCase and also adds  tests for other blacklisted classes.