### PR TITLE
[JBEAP-14635] Activate DatasourcesActiveCountTestCase

### DIFF
--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/core/jca/DatasourcesActiveCountTestCase.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/core/jca/DatasourcesActiveCountTestCase.java
@@ -53,7 +53,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap71x-Proposed/core/src/main/java#7.1.4"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap71x-Proposed/core/src/main/java#7.1.4","modules/testcases/jdkAll/Eap71x/core/src/main/java#7.1.4"})
 public class DatasourcesActiveCountTestCase extends AbstractCliTestBase {
 
    private static final String OP_PATTERN = "/subsystem=datasources/data-source=ExampleDS:write-attribute(name=%s,value=%s)";


### PR DESCRIPTION
The PR with the fix  ( ironjacamar/ironjacamar#665 ) is now merged and ready for EAP 7.1.4, so the test case can be enabled.