### PR TITLE
[JBEAP-15080] Don't use a sun internal class in SecurityDeserializationTestCase

### DIFF
--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/security/other/SecurityDeserializationTestCase.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/security/other/SecurityDeserializationTestCase.java
@@ -59,7 +59,7 @@ public class SecurityDeserializationTestCase {
 
         final String JSON = aposToQuotes(
                 "{'id': 1111,\n"
-                + " 'obj':[ 'com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl',\n"
+                + " 'obj':[ 'org.apache.xalan.xsltc.trax.TemplatesImpl',\n"
                 + "  {\n"
                 + "    'transletBytecodes' : [ 'AAIAZQ==' ],\n"
                 + "    'transletName' : 'a.b',\n"


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-15080

Don't use a sun internal class in SecurityDeserializationTestCase. This causes failures when IBM jdk is used. I've replaces it with the "vanilla" xalan impl as it was also part of the same fix, so it should be equivalent as far as the test is concerned.