### PR TITLE
[JBEAP-15389] Add test coverage for WrappedMessageContext containsKey

### DIFF
--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/ContainsKeyService.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/ContainsKeyService.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.additional.testsuite.jdkall.present.basic.ws;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+
+// TODO: Enable once https://issues.jboss.org/browse/WFLY-11204 gets resolved
+//@apAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/basic/src/main/java#15.0.0","modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@WebService(targetNamespace = "http://www.jboss.org/eap/additional/ts/ContainsKey")
+public interface ContainsKeyService {
+
+    @WebMethod
+    boolean testContainsKey();
+
+}

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/ContainsKeyServiceImpl.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/ContainsKeyServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.additional.testsuite.jdkall.present.basic.ws;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import javax.jws.HandlerChain;
+import javax.jws.WebService;
+
+// TODO: Enable once https://issues.jboss.org/browse/WFLY-11204 gets resolved
+//@apAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/basic/src/main/java#15.0.0","modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@WebService(
+    serviceName = ContainsKeyServiceImpl.SERVICE_NAME,
+    portName = "ContainsKey",
+    name = "ContainsKey",
+    endpointInterface = "org.jboss.additional.testsuite.jdkall.present.basic.ws.ContainsKeyService",
+    targetNamespace = ContainsKeyServiceImpl.NAMESPACE)
+@HandlerChain(file = "/handlers.xml")
+public class ContainsKeyServiceImpl implements ContainsKeyService {
+
+    public static final String SERVICE_NAME = "ContainsKeyService";
+    public static final String NAMESPACE = "http://www.jboss.org/eap/additional/ts/ContainsKey";
+
+    @Override
+    public boolean testContainsKey() {
+        return Handler.containsKey;
+    }
+}

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/Handler.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/Handler.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.additional.testsuite.jdkall.present.basic.ws;
+
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+
+import javax.xml.ws.handler.LogicalHandler;
+import javax.xml.ws.handler.LogicalMessageContext;
+import javax.xml.ws.handler.MessageContext;
+
+
+// TODO: Enable once https://issues.jboss.org/browse/WFLY-11204 gets resolved
+//@apAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/basic/src/main/java#15.0.0","modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+public class Handler implements LogicalHandler<LogicalMessageContext> {
+
+    public static boolean containsKey = false;
+
+    @Override
+    public boolean handleMessage(LogicalMessageContext context) {
+        boolean outbound = (Boolean) context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+        if (!outbound) {
+            containsKey = context.containsKey(MessageContext.HTTP_REQUEST_HEADERS);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(LogicalMessageContext context) {
+        return false;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+
+    }
+}

--- a/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/MessageContextTestCase.java
+++ b/modules/src/main/java/org/jboss/additional/testsuite/jdkall/present/basic/ws/MessageContextTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.additional.testsuite.jdkall.present.basic.ws;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.additional.testsuite.annotations.EapAdditionalTestsuite;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.Service;
+import javax.xml.ws.handler.MessageContext;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test that Jax-WS MessageContext works correctly.
+ *
+ * @author <a href="mailto:pmackay@redhat.com">Peter Mackay</a>
+ */
+// TODO: Enable once https://issues.jboss.org/browse/WFLY-11204 gets resolved
+//@apAdditionalTestsuite({"modules/testcases/jdkAll/Wildfly/basic/src/main/java#15.0.0","modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@EapAdditionalTestsuite({"modules/testcases/jdkAll/Eap72x-Proposed/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap72x/basic/src/main/java#7.2.1","modules/testcases/jdkAll/Eap71x-Proposed/basic/src/main/java#7.1.6","modules/testcases/jdkAll/Eap71x/basic/src/main/java#7.1.6"})
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MessageContextTestCase {
+
+    private static final String DEPLOYMENT_NAME = "JaxWSMessageContextTest";
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war");
+        war.addClasses(ContainsKeyService.class, ContainsKeyServiceImpl.class, Handler.class);
+        war.addAsWebInfResource("handlers.xml", "classes/handlers.xml");
+        return war;
+    }
+
+    /**
+     * Test that the WrappedMessageContext#containsKey method is consistent.
+     * See https://issues.jboss.org/browse/JBEAP-15389
+     */
+    @Test
+    public void testContainsKey(@ArquillianResource URL deploymentUrl) throws MalformedURLException {
+        QName serviceName = new QName(ContainsKeyServiceImpl.NAMESPACE, ContainsKeyServiceImpl.SERVICE_NAME);
+        URL wsdlUrl = new URL(deploymentUrl.toExternalForm() + ContainsKeyService.class.getSimpleName() + "?wsdl");
+        Service service = Service.create(wsdlUrl, serviceName);
+        ContainsKeyService containsKeyService = service.getPort(ContainsKeyService.class);
+
+        Map<String, Object> requestContext = ((BindingProvider) containsKeyService).getRequestContext();
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("header", Arrays.asList("value"));
+        requestContext.put(MessageContext.HTTP_REQUEST_HEADERS, headers);
+
+        Assert.assertTrue("The containsKey method returned false. See https://issues.jboss.org/browse/JBEAP-15389",
+            containsKeyService.testContainsKey());
+    }
+
+}

--- a/modules/testcases/jdkAll/Eap71x-Proposed/basic/test-configurations/src/test/resources/handlers.xml
+++ b/modules/testcases/jdkAll/Eap71x-Proposed/basic/test-configurations/src/test/resources/handlers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="http://java.sun.com/xml/ns/javaee">
+    <handler-chain>
+        <handler>
+            <handler-name>TestHandler</handler-name>
+            <handler-class>org.jboss.additional.testsuite.jdkall.present.basic.ws.Handler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>

--- a/modules/testcases/jdkAll/Eap71x/basic/test-configurations/src/test/resources/handlers.xml
+++ b/modules/testcases/jdkAll/Eap71x/basic/test-configurations/src/test/resources/handlers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="http://java.sun.com/xml/ns/javaee">
+    <handler-chain>
+        <handler>
+            <handler-name>TestHandler</handler-name>
+            <handler-class>org.jboss.additional.testsuite.jdkall.present.basic.ws.Handler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>

--- a/modules/testcases/jdkAll/Eap72x-Proposed/basic/test-configurations/src/test/resources/handlers.xml
+++ b/modules/testcases/jdkAll/Eap72x-Proposed/basic/test-configurations/src/test/resources/handlers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="http://java.sun.com/xml/ns/javaee">
+    <handler-chain>
+        <handler>
+            <handler-name>TestHandler</handler-name>
+            <handler-class>org.jboss.additional.testsuite.jdkall.present.basic.ws.Handler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>

--- a/modules/testcases/jdkAll/Eap72x/basic/test-configurations/src/test/resources/handlers.xml
+++ b/modules/testcases/jdkAll/Eap72x/basic/test-configurations/src/test/resources/handlers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="http://java.sun.com/xml/ns/javaee">
+    <handler-chain>
+        <handler>
+            <handler-name>TestHandler</handler-name>
+            <handler-class>org.jboss.additional.testsuite.jdkall.present.basic.ws.Handler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>

--- a/modules/testcases/jdkAll/Wildfly/basic/test-configurations/src/test/resources/handlers.xml
+++ b/modules/testcases/jdkAll/Wildfly/basic/test-configurations/src/test/resources/handlers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="http://java.sun.com/xml/ns/javaee">
+    <handler-chain>
+        <handler>
+            <handler-name>TestHandler</handler-name>
+            <handler-class>org.jboss.additional.testsuite.jdkall.present.basic.ws.Handler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>


### PR DESCRIPTION
ISSUE:
https://issues.jboss.org/browse/JBEAP-15389 - WrappedMessageContext containsKey not consistent with get/put

The issue seems to still be present in latest wildfly, so I didn't include it for now.