### PR TITLE
Switch all maven caches to https

### DIFF
--- a/run-eat.sh
+++ b/run-eat.sh
@@ -8,6 +8,8 @@ readonly SMODE=${2}
 readonly NAME_PREFIX=${NAME_PREFIX:-'jboss-eap'}
 readonly SETTINGS_XML=${SETTINGS_XML:-"$(pwd)/settings.xml"}
 
+readonly MAVEN_CACHE_SERVER=${MAVEN_CACHE_SERVER:-$(hostname)}
+
 set -u
 
 usage() {
@@ -77,6 +79,10 @@ fi
 
 if [ -e "${SETTINGS_XML}" ]; then
   readonly SETTINGS_XML_OPTION="-s ${SETTINGS_XML}"
+   # see https://projects.engineering.redhat.com/browse/SET-126
+  sed -i  "${SETTINGS_XML}" \
+      -e "s;MAVEN_CACHE_SERVER;${MAVEN_CACHE_SERVER};"
+
 else
   readonly SETTINGS_XML_OPTION=''
 fi

--- a/settings.xml
+++ b/settings.xml
@@ -23,28 +23,28 @@ under the License.
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <mirrors>
     <mirror>
-      <id>thunder.maven.central.cache</id>
+      <id>MAVEN_CACHE_SERVER.maven.central.cache</id>
       <mirrorOf>central</mirrorOf>
       <name>Thunder Maven Central Cache</name>
-      <url>https://thunder/maven</url>
+      <url>https://MAVEN_CACHE_SERVER/maven</url>
     </mirror>
     <mirror>
-      <id>thunder.jboss-eap-7.1-product-repository</id>
+      <id>MAVEN_CACHE_SERVER.jboss-eap-7.1-product-repository</id>
       <mirrorOf>jboss-eap-7.1-product-repository</mirrorOf>
       <name>Thunder Product EAP Cache</name>
-      <url>https://thunder/eap-7.1/</url>
+      <url>https://MAVEN_CACHE_SERVER/eap-7.1/</url>
     </mirror>
     <mirror>
-      <id>thunder.jboss-eap-7.0-product-repository</id>
+      <id>MAVEN_CACHE_SERVER.jboss-eap-7.0-product-repository</id>
       <mirrorOf>jboss-product-repository</mirrorOf>
       <name>Thunder Product EAP 7.0 Cache</name>
-      <url>https://thunder/eap-7.0</url>
+      <url>https://MAVEN_CACHE_SERVER/eap-7.0</url>
     </mirror>
     <mirror>
-      <id>thunder.jboss.org.cache</id>
+      <id>MAVEN_CACHE_SERVER.jboss.org.cache</id>
       <mirrorOf>jboss-public-repository-group</mirrorOf>
       <name>Thunder JBoss Public Repositories Cache</name>
-      <url>https://thunder/jboss</url>
+      <url>https://MAVEN_CACHE_SERVER/jboss</url>
     </mirror>
   </mirrors>
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -26,25 +26,25 @@ under the License.
       <id>thunder.maven.central.cache</id>
       <mirrorOf>central</mirrorOf>
       <name>Thunder Maven Central Cache</name>
-      <url>http://thunder.sin2.redhat.com/maven</url>
+      <url>https://thunder/maven</url>
     </mirror>
     <mirror>
       <id>thunder.jboss-eap-7.1-product-repository</id>
       <mirrorOf>jboss-eap-7.1-product-repository</mirrorOf>
       <name>Thunder Product EAP Cache</name>
-      <url>http://thunder.sin2.redhat.com/eap-7.1/</url>
+      <url>https://thunder/eap-7.1/</url>
     </mirror>
     <mirror>
       <id>thunder.jboss-eap-7.0-product-repository</id>
       <mirrorOf>jboss-product-repository</mirrorOf>
       <name>Thunder Product EAP 7.0 Cache</name>
-      <url>http://thunder.sin2.redhat.com/eap-7.0</url>
+      <url>https://thunder/eap-7.0</url>
     </mirror>
     <mirror>
       <id>thunder.jboss.org.cache</id>
       <mirrorOf>jboss-public-repository-group</mirrorOf>
       <name>Thunder JBoss Public Repositories Cache</name>
-      <url>http://thunder.sin2.redhat.com/jboss</url>
+      <url>https://thunder/jboss</url>
     </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
@panossot When you will merge this change, it will update all the EAT jobs to use https insteand of http for all the cache. It is important to do so, because the plain http caches will be removed soon. 

**WARNING** 
* You need to update all your EAT jobs to use the JDK 1.8.0_181 (and not the "System" one), as this JDK has the self sign certificate for Thunder). Otherwise, the job will failed [like that](https://thunder.sin2.redhat.com/jenkins/job/EAT-wildfly-build/1290/). 
* You will also need to add a new paramter MAVEN_CACHE_SERVER (see how it was done for [EAT-wildfly-build](https://thunder.sin2.redhat.com/jenkins/job/EAT-wildfly-build/1294/))

Note that I have modify EAT-Widlfy to test this change, so that you can see it works. You'll need to revert this job to your github repository after merging this change.

