### PR TITLE
Enhance run eat to support other args and some file cleaning

### DIFF
--- a/oldScripts/run-quarkus-native.sh
+++ b/oldScripts/run-quarkus-native.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+readonly NATIVE=${NATIVE:-''} # export NATIVE=-Pnative
 
 sed -i 's/${QUARKUS_VERSION}/'"${QUARKUS_VERSION}"'/g' ./modules/testcases/jdkAll/Protean/quarkus/quark/test-configurations/pom.xml
-./Maven/apache-maven-3.5.3/bin/mvn clean install -Dquarkus -DJBOSS_VERSION=${JBOSS_VERSION} -Dquarkus-project-discovery=false -Dquarkus-cp-cache=false -Dquarkus-workspace-discovery=false -Dquarkus-classpath-cache=false
+./Maven/apache-maven-3.5.3/bin/mvn clean install -Dquarkus "${NATIVE}"-DJBOSS_VERSION=${JBOSS_VERSION} -Dquarkus-project-discovery=false -Dquarkus-cp-cache=false -Dquarkus-workspace-discovery=false -Dquarkus-classpath-cache=false
 sed -i 's/<version>'"${QUARKUS_VERSION}"'<\/version>/<version>${QUARKUS_VERSION}<\/version>/g' ./modules/testcases/jdkAll/Protean/quarkus/quark/test-configurations/pom.xml
 

--- a/run-eat.sh
+++ b/run-eat.sh
@@ -129,6 +129,5 @@ export MAVEN_OPTS="${MAVEN_OPTS} -Xmx1024m -Xms512m -XX:MaxPermSize=256m"
 #
 # Run EAT
 #
-echo "Runing EAT on JBoss server: ${JBOSS_FOLDER}  ${EAT_EXTRA_OPTS}"
+echo "Runing EAT on JBoss server: ${JBOSS_FOLDER} - using extra opts: ${EAT_EXTRA_OPTS}"
 mvn clean install -D${JBOSS_VERSION_CODE} ${SMODE_CONFIG} ${SETTINGS_XML_OPTION} ${MAVEN_LOCAL_REPOSITORY_OPTION} ${EAT_EXTRA_OPTS}
-

--- a/run-quarkus.sh
+++ b/run-quarkus.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+readonly NATIVE=${NATIVE:-''} # export NATIVE=-Pnative
 
 sed -i 's/${QUARKUS_VERSION}/'"${QUARKUS_VERSION}"'/g' ./modules/testcases/jdkAll/Protean/quarkus/quark/test-configurations/pom.xml
-./Maven/apache-maven-3.5.3/bin/mvn clean install -Dquarkus  -Dnative -DJBOSS_VERSION=${JBOSS_VERSION}  -Dquarkus-project-discovery=false -Dquarkus-cp-cache=false -Dquarkus-workspace-discovery=false -Dquarkus-classpath-cache=false
+./Maven/apache-maven-3.5.3/bin/mvn clean install -Dquarkus "${NATIVE}"-DJBOSS_VERSION=${JBOSS_VERSION} -Dquarkus-project-discovery=false -Dquarkus-cp-cache=false -Dquarkus-workspace-discovery=false -Dquarkus-classpath-cache=false
 sed -i 's/<version>'"${QUARKUS_VERSION}"'<\/version>/<version>${QUARKUS_VERSION}<\/version>/g' ./modules/testcases/jdkAll/Protean/quarkus/quark/test-configurations/pom.xml
 


### PR DESCRIPTION
@panossot This change introduce a new env variable OTHER_MAVEN_ARGS to allow passing extra parameters to maven. This will allow removing the run-eat-with-http.sh by doing so:

```
export OTHER_MAVEN_ARGS=' -Dmaven.repository.protocol=http -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true’ ./run-eat.sh 
```

I know you you don’t mind code duplication, but IMHO you should really NOT duplicate the run-eat.sh script. For instance, the recent fix from @spyrkob that allows using run-eat.sh without using a settings.xml has not made it in the run-eat-with-http.sh file. Which means that now those two scripts have different behaviors. Also, if we found an issue in run-eat.sh and fix it there, the job using the run-eat-with-http.sh will not get the fix and may fail, later on, because of something actually already fixed.

If you need to change the behavior of run-eat.sh, I would strongly recommend you try to enhance the script to support it and configure the job accordingly. (Feel free to ask me or Bart, about that, if you have no idea how to enhance the script)

BTW, I would also remove the Jenkins-job.sh script which has been abandoned for a while now, this file is just littering your project and brings no value.