### PR TITLE
JBEAP-18447: Implementing test case for shared sessions passivation

### DIFF
--- a/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/Mutable.java
+++ b/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/Mutable.java
@@ -1,0 +1,46 @@
+package org.server.test.infinispan.distributable;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * A simple class to be used by the servlet in order to generate values 
+ * to be stored by the session.
+ */
+public class Mutable implements Serializable {
+
+    private static final long serialVersionUID = -5129400250276547619L;
+    private transient boolean serialized = false;
+    private int value;
+
+    public Mutable(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+
+    public void increment() {
+        this.value += 1;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.value);
+    }
+
+    public boolean wasSerialized() {
+        return this.serialized;
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        this.serialized = true;
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        this.serialized = true;
+    }
+}

--- a/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/SharedSessionPassivationTestCase.java
+++ b/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/SharedSessionPassivationTestCase.java
@@ -1,0 +1,154 @@
+package org.server.test.infinispan.distributable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.nio.file.Paths;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+
+import org.server.test.infinispan.distributable.log.LogChecker;
+import org.server.test.infinispan.distributable.log.ModelNodeLogChecker;
+import org.jboss.arquillian.container.test.api.Deployer;
+
+/**
+ * Validate that sessions aren't passivated when {@code <distributable/>} is used.
+ * Default HA configuration is used, i.e. <b>standalone-ha.xml</b>, default Inifinispan subsytem configuration,
+ * secifically defaul file store path.
+ * The only configuration is represented by {@code <distributable/>}, which is added to the <b>web.xml</b>
+ *
+ * See https://issues.redhat.com/browse/JBEAP-18447
+ */
+@RunWith(Arquillian.class)
+public class SharedSessionPassivationTestCase {
+
+    private static final String MODULE_NAME = SharedSessionPassivationTestCase.class.getSimpleName();
+    private static final String MANAGED_DEPLOYMENT = "deployment";
+    private static final String APPLICATION_NAME = MODULE_NAME + ".war";
+    private static final String WEB_XML =
+            "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
+            "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n" +
+            "         version=\"3.0\">\n" +
+            "    <distributable/>\n" +
+            "</web-app>\n";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(name = MANAGED_DEPLOYMENT, managed = false, testable = false)
+    public static Archive<?> deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APPLICATION_NAME);
+        war.addClasses(SimpleServlet.class, Mutable.class);
+        war.setWebXML(new StringAsset(WEB_XML));
+        return war;
+    }
+
+    private String getDefaultCacheFileStorePath() {
+        final String separator = FileSystems.getDefault().getSeparator();
+        return System.getProperty("jboss.home")
+                .concat(separator)
+                .concat("standalone")
+                .concat(separator)
+                .concat("data")
+                .concat(separator)
+                .concat("infinispan")
+                .concat(separator)
+                .concat("web")
+                .concat(separator)
+                .concat(APPLICATION_NAME + ".dat");
+    }
+
+    /**
+     * Deploy all deployments so it's possible to get their URLs in other tests. This is limitation of Arquillian
+     * when deployments are deployed manually (in tests) and thus their URL is not known in time when test is started.
+     * The workaround for this issue is to deploy all deployments in first test which allows to inject
+     * deployment URL as params in other test methods.
+     */
+    @Test
+    @InSequence(1)
+    public void deployAll() {
+        deployer.deploy(MANAGED_DEPLOYMENT);
+    }
+
+    /**
+     * Deploys the WAR archive to the server and then performs http calls in order to create sessions.
+     * Intermediate and final verifications - i.e. before and after undeployment - are executed to assess that file
+     * store contents aren't changed. Finally the log is checked to verify that no messages were logged by the
+     * Infinispan subsystem withh respect to entries passivation.
+     *
+     * @param baseURL Base URL to reach the deployment
+     * @param managementClient Instance of ManagmentClient provided by Arquillian.
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    @Test
+    @InSequence(10)
+    @OperateOnDeployment(MANAGED_DEPLOYMENT)
+    public void test(@ArquillianResource(SimpleServlet.class) URL baseURL,
+                     @ArquillianResource @OperateOnDeployment(MANAGED_DEPLOYMENT) ManagementClient managementClient)
+            throws IOException, URISyntaxException {
+
+        final String cacheFileStorePath = getDefaultCacheFileStorePath();
+        final byte[] cacheFileStoreInitialContent = Files.readAllBytes(Paths.get(cacheFileStorePath));
+
+        URI uri = SimpleServlet.createURI(baseURL);
+
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
+            HttpResponse response = client.execute(new HttpGet(uri));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            response = client.execute(new HttpGet(uri));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+        }
+
+        final byte[] cacheFileStoreIntermediateContent = Files.readAllBytes(Paths.get(cacheFileStorePath));
+        Assert.assertArrayEquals("Initial and intermediate file store contents differ",
+                cacheFileStoreInitialContent, cacheFileStoreIntermediateContent);
+
+        //  udeployment will cause passivation before JBEAP-18447
+        deployer.undeploy(MANAGED_DEPLOYMENT);
+
+        final byte[] cacheFileStoreFinalContent = Files.readAllBytes(Paths.get(cacheFileStorePath));
+        Assert.assertArrayEquals("Initial and final file store contents differ",
+                cacheFileStoreInitialContent, cacheFileStoreFinalContent);
+
+        LogChecker logChecker = new ModelNodeLogChecker(managementClient, 30, true);
+        Assert.assertFalse("Log contains message ID \"ISPN000029\", related to entries about to be passivated",
+                logChecker.logContains("ISPN000029"));
+        Assert.assertFalse("Log contains message ID \"ISPN000030\", related to successfully passivated entries",
+                logChecker.logContains("ISPN000030"));
+    }
+}

--- a/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/SimpleServlet.java
+++ b/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/SimpleServlet.java
@@ -1,0 +1,82 @@
+package org.server.test.infinispan.distributable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * Simple servlet as from Wildfly TS
+ */
+@WebServlet(urlPatterns = { SimpleServlet.SERVLET_PATH })
+public class SimpleServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -592774116315946908L;
+    private static final String SERVLET_NAME = "simple";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    public static final String REQUEST_DURATION_PARAM = "requestduration";
+    public static final String HEADER_SERIALIZED = "serialized";
+    public static final String VALUE_HEADER = "value";
+    public static final String SESSION_ID_HEADER = "sessionId";
+    public static final String ATTRIBUTE = "test";
+    public static final String HEADER_NODE_NAME = "nodename";
+
+    public static URI createURI(URL baseURL) throws URISyntaxException {
+        return createURI(baseURL.toURI());
+    }
+
+    public static URI createURI(URI baseURI) {
+        return baseURI.resolve(SERVLET_NAME);
+    }
+
+    public static URI createURI(URL baseURL, int requestDuration) throws URISyntaxException {
+        return createURI(baseURL.toURI(), requestDuration);
+    }
+
+    public static URI createURI(URI baseURI, int requestDuration) {
+        return baseURI.resolve(SERVLET_NAME + '?' + REQUEST_DURATION_PARAM + '=' + requestDuration);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        HttpSession session = req.getSession(true);
+        resp.addHeader(SESSION_ID_HEADER, session.getId());
+        Mutable custom = (Mutable) session.getAttribute(ATTRIBUTE);
+        if (custom == null) {
+            if (!session.isNew()) throw new IllegalStateException();
+            custom = new Mutable(1);
+            session.setAttribute(ATTRIBUTE, custom);
+        } else {
+            if (session.isNew()) throw new IllegalStateException();
+            custom.increment();
+        }
+        resp.setIntHeader(VALUE_HEADER, custom.getValue());
+        resp.setHeader(HEADER_SERIALIZED, Boolean.toString(custom.wasSerialized()));
+
+        try {
+            String nodeName = System.getProperty("jboss.node.name");
+            resp.setHeader(HEADER_NODE_NAME, nodeName);
+        } catch (Exception ignore) {
+        }
+
+        this.getServletContext().log(req.getRequestURI() + ", value = " + custom.getValue());
+
+        // Long running request?
+        if (req.getParameter(REQUEST_DURATION_PARAM) != null) {
+            int duration = Integer.parseInt(req.getParameter(REQUEST_DURATION_PARAM));
+            try {
+                Thread.sleep(duration);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        resp.getWriter().write("Success");
+    }
+}

--- a/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/log/LogChecker.java
+++ b/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/log/LogChecker.java
@@ -1,0 +1,26 @@
+package org.server.test.infinispan.distributable.log;
+
+import java.util.regex.Pattern;
+
+/**
+ * Interface describing utility which checks a log
+ */
+public interface LogChecker {
+
+    /**
+     * Perform search in log or its excerpt and find if a line matches the pattern.
+     * 
+     * @param pattern a pattern which will be the log line matched against
+     * @return true if log line matching pattern was found in log, false otherwise
+     */
+    boolean logMatches(final Pattern pattern);
+
+    /**
+     * Perform search in log or its excerpt and find if a line contains a sub string.
+     * 
+     * @param subString a sub string which will be used to perform search among lines
+     * @return true if log line containing a sub string was found in log, false otherwise
+     */
+    boolean logContains(final String subString);
+
+}

--- a/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/log/ModelNodeLogChecker.java
+++ b/SingleVersionTestInclusion/wildfly/src/test/java/org/server/test/infinispan/distributable/log/ModelNodeLogChecker.java
@@ -1,0 +1,98 @@
+package org.server.test.infinispan.distributable.log;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.jboss.dmr.ModelNode;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.junit.Assert;
+
+/**
+ * Log checker based on accessing messages through {@link org.jboss.dmr.ModelNode} returned from {@code :read-log-file}
+ * operation.
+ */
+public final class ModelNodeLogChecker implements LogChecker {
+
+    private static final String READ_LOG_FILE_OPERATION = "read-log-file";
+
+    private final ManagementClient client;
+    private final int countOfLines;
+    private final boolean readLogFromEnd;
+
+    /**
+     * Create an instance of log checker. File will be read from the end (tail).
+     * 
+     * @param client client which will be used to invoke log file reading operation on server
+     * @param countOfLines number of lines which will be read. -1 means all lines will be read. Be careful, that log
+     *        files can get pretty big and reading whole file may lead to serious memory issues.
+     */
+    public ModelNodeLogChecker(final ManagementClient client, final int countOfLines) {
+        this(client, countOfLines, true);
+    }
+
+    /**
+     * Create an instance of log checker
+     * 
+     * @param client client which will be used to invoke log file reading operation on server
+     * @param countOfLines number of lines which will be read. -1 means all lines will be read. Be careful, that log
+     *        files can get pretty big and reading whole file may lead to serious memory issues.
+     * @param readFromEnd true if log file should be read in tail mode
+     */
+    public ModelNodeLogChecker(final ManagementClient client, final int countOfLines, final boolean readFromEnd) {
+        this.client = client;
+        this.countOfLines = countOfLines;
+        this.readLogFromEnd = readFromEnd;
+    }
+
+    @Override
+    public boolean logMatches(Pattern pattern) {
+        try {
+            return anyLineMatchesPredicate(readLogFileFromManagementModel(),
+                    (final String line) -> pattern.matcher(line).matches());
+
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean logContains(String subString) {
+        try {
+            return anyLineMatchesPredicate(readLogFileFromManagementModel(),
+                    (final String line) -> line.contains(subString));
+
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private ModelNode readLogFileFromManagementModel() throws IOException {
+
+        final ModelNode op = new ModelNode();
+
+        op.get(ModelDescriptionConstants.OP).set(READ_LOG_FILE_OPERATION);
+        op.get(ModelDescriptionConstants.OP_ADDR).add("subsystem", "logging");
+        op.get("name").set("server.log");
+        op.get("tail").set(this.readLogFromEnd);
+        op.get("lines").set(this.countOfLines);
+
+        final ModelNode result = this.client.getControllerClient().execute(op);
+        Assert.assertEquals("Management operation failed:\n" + result.toString() + "\n",
+                ModelDescriptionConstants.SUCCESS, result.get(ModelDescriptionConstants.OUTCOME).asString());
+
+        return result;
+    }
+
+    private boolean anyLineMatchesPredicate(final ModelNode logLines, final Predicate<String> predicate) {
+        final Optional<String> optionalMatch = logLines.asList()
+                .stream()
+                .map(ModelNode::asString)
+                .filter(predicate)
+                .findFirst();
+
+        return optionalMatch.isPresent();
+    }
+
+}


### PR DESCRIPTION
Adding test to validate that web sessions aren't passivated when `<distributable` is used.
Default HA configuration is used, i.e. <b>standalone-ha.xml</b>, default Inifinispan subsytem configuration and specifically default file store path.
The only additional configuration is represented by the `<distributable/>` element, which is added to the `web.xml` file.

To execute the test:

1. See https://github.com/jboss-set/eap-additional-testsuite/tree/master/SingleVersionTestInclusion

2. Execute Maven specifying a `standalone-ha.xml` config file:
```
$ cd SingleVersionTestInclusion/wildfly
$ mvn clean install -Djboss.server.config.file.name=standalone-ha.xml
```

See https://issues.redhat.com/browse/WFLY-12954

The test is expected to fail against EAP 7.2.5 and to succeed against Wildfly 19.0.0.Beta1.